### PR TITLE
feat: wallet configuration

### DIFF
--- a/specs/Contracts.spec.ts
+++ b/specs/Contracts.spec.ts
@@ -57,7 +57,7 @@ describe('ETH tests', () => {
     })
 
     it('should call .connect({}) and it works', async () => {
-      const r = await eth.connect({ providerUrl: 'http://localhost:7654' })
+      const r = await eth.connect({ provider: 'http://localhost:7654' })
       expect(r).to.eq(true)
     })
 

--- a/src/ethereum/eth.ts
+++ b/src/ethereum/eth.ts
@@ -1,4 +1,4 @@
-import { NodeWallet, LedgerWallet } from './wallets'
+import { NodeWallet } from './wallets'
 import { ethUtils } from './ethUtils'
 import { promisify } from '../utils/index'
 import { Contract } from './Contract'
@@ -8,12 +8,11 @@ import { Wallet } from './wallets/Wallet'
 export type ConnectOptions = {
   /** An array of objects defining contracts or Contract subclasses to use. Check {@link eth#setContracts} */
   contracts?: any[]
-  /** Override the default account address */
-  defaultAccount?: any
+  /** An array of Wallet classes. Check {@link wallets} */
+  wallets?: Wallet[]
   /** URL for a provider forwarded to {@link Wallet#getWeb3Provider} */
   providerUrl?: string
   provider?: object
-  derivationPath?: string
 }
 
 export namespace eth {
@@ -31,11 +30,10 @@ export namespace eth {
   /**
    * Connect to web3
    * @param  {object} [options] - Options for the ETH connection
-   * @param  {array<Contract>} [options.contracts=[]] - An array of objects defining contracts or Contract subclasses to use. Check {@link eth#setContracts}
-   * @param  {string} [options.defaultAccount=web3.eth.accounts[0]] - Override the default account address
+   * @param  {array<Contract>} [options.contracts=[NodeWallet]] - An array of objects defining contracts Defaults to a NodeWallet instance. Check {@link eth#setContracts}
+   * @param  {array<Wallet>} [options.wallets=[]] - An array of Wallet instances. It'll use the first successful connection. Check {@link wallets}
    * @param  {string} [options.providerUrl] - URL for a provider forwarded to {@link Wallet#getWeb3Provider}
    * @param  {string} [options.provider] - A provider given by other library/plugin
-   * @param  {string} [options.derivationPath] - Path to derive the hardware wallet in. Defaults to each wallets most common value
    * @return {boolean} - True if the connection was successful
    */
   export async function connect(options: ConnectOptions = {}) {
@@ -43,10 +41,10 @@ export namespace eth {
       disconnect()
     }
 
-    const { defaultAccount, provider, providerUrl, derivationPath } = options
+    const { wallets = [new NodeWallet()], provider, providerUrl } = options
 
     try {
-      wallet = await connectWallet(defaultAccount, provider || providerUrl, derivationPath)
+      wallet = await connectWallet(wallets, provider || providerUrl)
 
       // connect old contracts
       await setContracts(Object.values(contracts))
@@ -61,28 +59,24 @@ export namespace eth {
     }
   }
 
-  export async function connectWallet(
-    defaultAccount: string,
-    provider: object | string = '',
-    derivationPath = null
-  ): Promise<any> {
-    let wallet: Wallet
+  export async function connectWallet(wallets: Wallet[], provider: object | string): Promise<Wallet> {
     const networks = getNetworks()
+    const network =
+      typeof provider === 'string'
+        ? networks.find(network => provider.includes(network.name)) || networks[0]
+        : networks[0]
 
-    try {
-      const network =
-        typeof provider === 'string'
-          ? networks.find(network => provider.includes(network.name)) || networks[0]
-          : networks[0]
-
-      wallet = new LedgerWallet(defaultAccount, derivationPath)
-      await wallet.connect(provider, network.id)
-    } catch (error) {
-      wallet = new NodeWallet(defaultAccount)
-      await wallet.connect(provider)
+    const errors = []
+    for (const wallet of wallets) {
+      try {
+        await wallet.connect(provider, network.id)
+        return wallet
+      } catch (error) {
+        errors.push(error.message)
+      }
     }
 
-    return wallet
+    throw new Error(errors.join('\n'))
   }
 
   export function isConnected() {

--- a/src/ethereum/eth.ts
+++ b/src/ethereum/eth.ts
@@ -10,9 +10,8 @@ export type ConnectOptions = {
   contracts?: any[]
   /** An array of Wallet classes. Check {@link wallets} */
   wallets?: Wallet[]
-  /** URL for a provider forwarded to {@link Wallet#getWeb3Provider} */
-  providerUrl?: string
-  provider?: object
+  /** A provider given by other library/plugin or an URL for a provider forwarded to {@link Wallet#getWeb3Provider} */
+  provider?: object | string
 }
 
 export namespace eth {
@@ -32,8 +31,7 @@ export namespace eth {
    * @param  {object} [options] - Options for the ETH connection
    * @param  {array<Contract>} [options.contracts=[NodeWallet]] - An array of objects defining contracts Defaults to a NodeWallet instance. Check {@link eth#setContracts}
    * @param  {array<Wallet>} [options.wallets=[]] - An array of Wallet instances. It'll use the first successful connection. Check {@link wallets}
-   * @param  {string} [options.providerUrl] - URL for a provider forwarded to {@link Wallet#getWeb3Provider}
-   * @param  {string} [options.provider] - A provider given by other library/plugin
+   * @param  {string} [options.provider = ''] - A provider given by other library/plugin or an URL for a provider forwarded to {@link Wallet#getWeb3Provider}
    * @return {boolean} - True if the connection was successful
    */
   export async function connect(options: ConnectOptions = {}) {
@@ -41,10 +39,10 @@ export namespace eth {
       disconnect()
     }
 
-    const { wallets = [new NodeWallet()], provider, providerUrl } = options
+    const { wallets = [new NodeWallet()], provider = '' } = options
 
     try {
-      wallet = await connectWallet(wallets, provider || providerUrl)
+      wallet = await connectWallet(wallets, provider)
 
       // connect old contracts
       await setContracts(Object.values(contracts))
@@ -61,12 +59,10 @@ export namespace eth {
 
   export async function connectWallet(wallets: Wallet[], provider: object | string): Promise<Wallet> {
     const networks = getNetworks()
-    const network =
-      typeof provider === 'string'
-        ? networks.find(network => provider.includes(network.name)) || networks[0]
-        : networks[0]
+    const network = networks.find(network => provider.toString().includes(network.name)) || networks[0]
 
     const errors = []
+
     for (const wallet of wallets) {
       try {
         await wallet.connect(provider, network.id)

--- a/src/ethereum/eth.ts
+++ b/src/ethereum/eth.ts
@@ -107,7 +107,7 @@ export namespace eth {
    * Set the Ethereum contracts to use on the `contracts` property. It builds a map of
    *   { [Contract Name]: Contract instance }
    * usable later via `.getContract`. Check {@link https://github.com/decentraland/decentraland-eth/tree/master/src/ethereum} for more info
-   * @param  {array<Contract|object>} contracts - An array comprised of a wide variety of options: objects defining contracts, Contract subclasses or Contract instances.
+   * @param  {array<Contract|object>} contracts - An array comprised Contract instances.
    */
   export async function setContracts(_contracts: Contract[]) {
     if (!isConnected()) {

--- a/src/ethereum/eth.ts
+++ b/src/ethereum/eth.ts
@@ -95,14 +95,6 @@ export namespace eth {
     return wallet.getAccount()
   }
 
-  export function getWalletAttributes() {
-    return {
-      account: wallet.account,
-      type: wallet.type,
-      derivationPath: wallet.derivationPath
-    }
-  }
-
   /**
    * Set the Ethereum contracts to use on the `contracts` property. It builds a map of
    *   { [Contract Name]: Contract instance }

--- a/src/ethereum/index.ts
+++ b/src/ethereum/index.ts
@@ -1,6 +1,9 @@
+import * as wallets from './wallets'
+
 export { eth } from './eth'
 export { Contract } from './Contract'
 export { Abi } from './abi'
 export { Event } from './Event'
 export { SignedMessage } from './SignedMessage'
 export { txUtils } from './txUtils'
+export { wallets }

--- a/src/ethereum/wallets/LedgerWallet.ts
+++ b/src/ethereum/wallets/LedgerWallet.ts
@@ -30,7 +30,7 @@ export class LedgerWallet extends Wallet {
     return 'ledger'
   }
 
-  async connect(providerUrl: string | object, networkId?: string) {
+  async connect(providerUrl: object | string, networkId?: string) {
     if (typeof providerUrl === 'object') {
       throw new Error('Ledger wallet only allows string providers')
     }

--- a/src/ethereum/wallets/NodeWallet.ts
+++ b/src/ethereum/wallets/NodeWallet.ts
@@ -13,7 +13,7 @@ export class NodeWallet extends Wallet {
     return 'node'
   }
 
-  async connect(provider: string | object) {
+  async connect(provider: object | string) {
     const theProvider = typeof provider === 'object' ? provider : await this.getProvider(provider)
 
     if (!theProvider) {

--- a/src/ethereum/wallets/Wallet.ts
+++ b/src/ethereum/wallets/Wallet.ts
@@ -20,7 +20,7 @@ export abstract class Wallet {
   web3 = null
   derivationPath = null
 
-  constructor(public account: string) {
+  constructor(public account?: string) {
     // stub
   }
 


### PR DESCRIPTION
Allows for an array of Wallet instances to be used by `eth.connect`. Example: https://github.com/decentraland/marketplace/pull/195/files#diff-42d52283afaced49eb9838e53b7d1891R18

Sorry if the PR goes a little out of script, fixing a `param` on the docs and removing a method, but I thought it might be easier to add it here. I can revert the commits.

Related:
- https://github.com/decentraland/marketplace/pull/195
- https://github.com/decentraland/commons/pull/66