### PR TITLE
fix: throw when the node connection fails

### DIFF
--- a/src/ethereum/wallets/NodeWallet.ts
+++ b/src/ethereum/wallets/NodeWallet.ts
@@ -24,9 +24,10 @@ export class NodeWallet extends Wallet {
 
     if (!this.account) {
       const accounts = await this.getAccounts()
-      if (accounts.length !== 0) {
-        this.setAccount(accounts[0])
+      if (accounts.length === 0) {
+        throw new Error('Could not connect to web3')
       }
+      this.setAccount(accounts[0])
     }
   }
 


### PR DESCRIPTION
So it can be catched [here](https://github.com/decentraland/decentraland-eth/blob/master/src/ethereum/eth.ts#L56)

This means that using the wallet outside eth should look like:

```javascript
try { 
 wallet.connect()
} catch() {
 // didn't work
}
```