### PR TITLE
fix: rename call and transaction to sendCall and sendTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import { abi } from './abis/MANAToken.json'
 
 const contract = new Contract('0xdeadbeef', abi)
 
-await contract.call('allowance', sender, receiver)
+await contract.sendCall('allowance', sender, receiver)
 await contract.transaction('lockMana', manaValue)
 ```
 

--- a/scripts/contracts/ContractFile.ts
+++ b/scripts/contracts/ContractFile.ts
@@ -39,11 +39,11 @@ export class ContractFile {
 
           if (stateMutability === 'view') {
             extensions[name] = `function(${args}) {
-            return this.call('${name}', ${args})
+            return this.sendCall('${name}', ${args})
           }`
           } else if (stateMutability === 'nonpayable') {
             extensions[name] = `function(${args}) {
-            return this.transaction('${name}', ${args})
+            return this.sendTransaction('${name}', ${args})
           }`
           }
           break

--- a/specs/Contracts.spec.ts
+++ b/specs/Contracts.spec.ts
@@ -138,7 +138,7 @@ function doTest() {
   })
 
   it('should fail by invoking an unexistent method', async () => {
-    expect(() => MANAFacade.call('asdasd')).to.throw()
+    expect(() => MANAFacade.sendCall('asdasd')).to.throw()
   })
 
   it('should fail by pointing to a contract to wrong address', function(done) {

--- a/src/contracts/DecentralandVesting.ts
+++ b/src/contracts/DecentralandVesting.ts
@@ -19,32 +19,32 @@ export class DecentralandVesting extends Contract {
   }
 
   async duration() {
-    const bigNumber: BigNumber = await this.call('duration')
+    const bigNumber: BigNumber = await this.sendCall('duration')
     return bigNumber.toNumber()
   }
 
   async cliff() {
-    const bigNumber: BigNumber = await this.call('cliff')
+    const bigNumber: BigNumber = await this.sendCall('cliff')
     return bigNumber.toNumber()
   }
 
   async vestedAmount() {
-    const bigNumber: BigNumber = await this.call('vestedAmount')
+    const bigNumber: BigNumber = await this.sendCall('vestedAmount')
     return eth.utils.fromWei(bigNumber.toNumber())
   }
 
   async releasableAmount() {
-    const bigNumber: BigNumber = await this.call('releasableAmount')
+    const bigNumber: BigNumber = await this.sendCall('releasableAmount')
     return eth.utils.fromWei(bigNumber.toNumber())
   }
 
   async released() {
-    const bigNumber: BigNumber = await this.call('released')
+    const bigNumber: BigNumber = await this.sendCall('released')
     return eth.utils.fromWei(bigNumber.toNumber())
   }
 
   async start() {
-    const bigNumber: BigNumber = await this.call('start')
+    const bigNumber: BigNumber = await this.sendCall('start')
     return bigNumber.toNumber()
   }
 }

--- a/src/contracts/LANDRegistry.ts
+++ b/src/contracts/LANDRegistry.ts
@@ -71,16 +71,6 @@ export class LANDRegistry extends Contract {
   async updateManyLandData(coordinates: { x: number; y: number }[], data: string) {
     const x = coordinates.map(coor => coor.x)
     const y = coordinates.map(coor => coor.y)
-    return this.transaction('updateManyLandData', x, y, data)
-  }
-
-  async assignNewParcel(x, y, address, opts = {}) {
-    opts = Object.assign({ gas: 4000000, gasPrice: 28 * 1e9 }, opts)
-    return this.transaction('assignNewParcel', x, y, address, opts)
-  }
-
-  async assignMultipleParcels(x: number, y: number, address: string, opts = {}) {
-    opts = Object.assign({ gas: 1000000, gasPrice: 28 * 1e9 }, opts)
-    return this.transaction('assignMultipleParcels', x, y, address, opts)
+    return this.sendTransaction('updateManyLandData', x, y, data)
   }
 }

--- a/src/contracts/MANAToken.ts
+++ b/src/contracts/MANAToken.ts
@@ -33,16 +33,16 @@ export class MANAToken extends Contract {
   }
 
   async approve(spender: string, mana: number) {
-    return this.transaction('approve', spender, eth.utils.toWei(mana))
+    return this.sendTransaction('approve', spender, eth.utils.toWei(mana))
   }
 
   async allowance(owner: string, spender: string) {
-    const assigned = await this.call('allowance', owner, spender)
+    const assigned = await this.sendCall('allowance', owner, spender)
     return eth.utils.fromWei(assigned)
   }
 
   async balanceOf(owner: string): Promise<number> {
-    const manaBalance = await this.call('balanceOf', owner)
+    const manaBalance = await this.sendCall('balanceOf', owner)
     return eth.utils.fromWei(manaBalance)
   }
 }

--- a/src/contracts/TerraformReserve.ts
+++ b/src/contracts/TerraformReserve.ts
@@ -18,7 +18,7 @@ export class TerraformReserve extends Contract {
   }
 
   lockManaWei(sender: string, mana, opts = { gas: 1200 }) {
-    // TODO: this unlock account method doesnt exist eth.unlockAccount()
-    return this.transaction('lockMana', sender, mana, opts)
+    // TODO: unlock account here?
+    return this.sendTransaction('lockMana', sender, mana, opts)
   }
 }

--- a/src/contracts/verification.ts
+++ b/src/contracts/verification.ts
@@ -12,9 +12,9 @@ export function fulfillContractMethods(instance: Contract, abi: any[]) {
       switch (type) {
         case 'function': {
           if (stateMutability === 'view') {
-            instance[name] = new Function(`return this.call('${name}', ...arguments)`)
+            instance[name] = new Function(`return this.sendCall('${name}', ...arguments)`)
           } else if (stateMutability === 'nonpayable') {
-            instance[name] = new Function(`return this.transaction('${name}', ...arguments)`)
+            instance[name] = new Function(`return this.sendTransaction('${name}', ...arguments)`)
           }
           break
         }

--- a/src/ethereum/Contract.ts
+++ b/src/ethereum/Contract.ts
@@ -30,16 +30,16 @@ export abstract class Contract<T = any> {
   }
 
   /**
-   * See {@link Contract#transaction}
+   * See {@link Contract#sendTransaction}
    */
-  static async transaction(method: Function, ...args): Promise<any> {
+  static async sendTransaction(method: Function, ...args): Promise<any> {
     return promisify(method)(...args)
   }
 
   /**
-   * See {@link Contract#call}
+   * See {@link Contract#sendCall}
    */
-  static async call(prop, ...args): Promise<any> {
+  static async sendCall(prop, ...args): Promise<any> {
     return promisify(prop.call)(...args)
   }
 
@@ -91,14 +91,14 @@ export abstract class Contract<T = any> {
    * @param  {...object} args   - Every argument after the name will be fordwarded to the transaction method, in order
    * @return {Promise} - promise that resolves when the transaction does
    */
-  transaction(method: string, ...args) {
+  sendTransaction(method: string, ...args) {
     if (!this.instance[method]) {
-      throw new Error(`${this.getContractName()}#transaction: Unknown method ${method}`)
+      throw new Error(`${this.getContractName()}#sendTransaction: Unknown method ${method}`)
     }
     if (typeof this.instance[method] !== 'function') {
-      throw new Error(`${this.getContractName()}#transaction: method ${method} is not a function`)
+      throw new Error(`${this.getContractName()}#sendTransaction: method ${method} is not a function`)
     }
-    return Contract.transaction(this.instance[method], ...args)
+    return Contract.sendTransaction(this.instance[method], ...args)
   }
 
   /**
@@ -107,14 +107,14 @@ export abstract class Contract<T = any> {
    * @param  {...object} args   - Every argument after the name will be fordwarded to the call function, in order
    * @return {Promise} - promise that resolves when the call does
    */
-  call(prop: string, ...args) {
+  sendCall(prop: string, ...args) {
     if (!this.instance[prop]) {
-      throw new Error(`${this.getContractName()}#call: Unknown method ${prop}`)
+      throw new Error(`${this.getContractName()}#sendCall: Unknown method ${prop}`)
     }
     if (!this.instance[prop].call) {
-      throw new Error(`${this.getContractName()}#call: property ${prop} has no call signature`)
+      throw new Error(`${this.getContractName()}#sendCall: property ${prop} has no call signature`)
     }
-    return Contract.call(this.instance[prop], ...args)
+    return Contract.sendCall(this.instance[prop], ...args)
   }
 
   getEvent(eventName) {

--- a/src/ethereum/wallets/NodeWallet.ts
+++ b/src/ethereum/wallets/NodeWallet.ts
@@ -44,12 +44,12 @@ export class NodeWallet extends Wallet {
   }
 
   async getAccounts(): Promise<any[]> {
-    return Contract.transaction(this.web3.eth.getAccounts)
+    return Contract.sendTransaction(this.web3.eth.getAccounts)
   }
 
   async sign(message: string) {
     const sign = this.web3.personal.sign.bind(this.web3.personal)
-    return Contract.transaction(sign, message, this.account)
+    return Contract.sendTransaction(sign, message, this.account)
   }
 
   async recover(message: string, signature: string) {


### PR DESCRIPTION
When compiling with babel, it transpiles hierarcy as:

```javascript
var _this = _possibleConstructorReturn(this, (MANAToken.__proto__ || Object.getPrototypeOf(MANAToken)).call(this, address, abi));
```

which sadly clashes with the `call` method.