### PR TITLE
feat: fail if the tx is dropped

### DIFF
--- a/specs/NodeConnectionFactory.ts
+++ b/specs/NodeConnectionFactory.ts
@@ -1,0 +1,54 @@
+const ganache = require('ganache-cli')
+
+export type ConnectionOptions = {
+  accounts?: Array<object>
+  debug?: boolean
+  logger?: object | Function
+  mnemonic?: string
+  port?: number
+  seed?: string
+  total_accounts?: number
+  fork?: string
+  network_id?: number
+  time?: Date
+  locked?: boolean
+  unlocked_accounts?: Array<string>
+  db_path?: string
+  account_keys_path?: string
+  vmErrorsOnRPCResponse?: boolean
+}
+
+export class NodeConnectionFactory {
+  connectionOptions: ConnectionOptions
+
+  constructor(options?: ConnectionOptions) {
+    this.assignConnectionOptions()
+  }
+
+  assignConnectionOptions(options?: ConnectionOptions) {
+    this.connectionOptions = {
+      accounts: [
+        {
+          balance: 100012300001 /* gas */,
+          secretKey: '0x8485898485bbe08a0a9b97fdf695aec8e9f1d196c589d4b6ff50a0232518b682'
+        }
+      ],
+      network_id: 3,
+      logger: {
+        log(...args) {
+          console.log(...args)
+        }
+      },
+      vmErrorsOnRPCResponse: true,
+      ...options
+    }
+  }
+
+  createProvider() {
+    return ganache.provider(this.connectionOptions)
+  }
+
+  createServer() {
+    return ganache.server(this.connectionOptions)
+  }
+}

--- a/specs/deployContract.ts
+++ b/specs/deployContract.ts
@@ -1,0 +1,33 @@
+export type Artifact = {
+  abi: object
+  bytecode: string
+}
+
+export async function deployContract(wallet, name: string, contract: Artifact) {
+  const account = await wallet.getAccount()
+
+  const newContract = await wallet.getContract(contract.abi)
+  const gasEstimate = await wallet.estimateGas({ data: contract.bytecode })
+
+  console.log(`> Will deploy contract ${name} with gas: ${gasEstimate}`)
+
+  const options = { from: account, data: contract.bytecode, gas: gasEstimate }
+
+  let resolver = null
+  let rejecter = null
+
+  const prom = new Promise<any>((x, y) => {
+    resolver = x
+    rejecter = y
+  })
+
+  newContract.new(options, function(err, myContract) {
+    if (err) {
+      rejecter(err)
+    } else {
+      resolver(myContract)
+    }
+  })
+
+  return prom
+}

--- a/specs/txUtils.spec.ts
+++ b/specs/txUtils.spec.ts
@@ -1,0 +1,116 @@
+import { expect } from 'chai'
+import { NodeConnectionFactory } from './NodeConnectionFactory'
+import { deployContract } from './deployContract'
+import { eth, txUtils } from '../dist'
+
+describe('txUtils tests', () => {
+  const DEFAULT_FETCH_DELAY = txUtils.TRANSACTION_FETCH_DELAY
+  const nodeConnectionFactory = new NodeConnectionFactory()
+  let provider
+
+  before(() => {
+    provider = nodeConnectionFactory.createProvider()
+    return eth.connect({ provider })
+  })
+
+  describe('.getTransaction', function() {
+    it('should return the transaction status and its recepeit', async function() {
+      this.timeout(100000)
+
+      const contract = await deployContract(eth.wallet, 'MANA', require('./fixtures/MANAToken.json'))
+      const { recepeit, ...tx } = await txUtils.getTransaction(contract.transactionHash)
+
+      expect(Object.keys(tx)).to.be.deep.equal([
+        'hash',
+        'nonce',
+        'blockHash',
+        'blockNumber',
+        'transactionIndex',
+        'from',
+        'to',
+        'value',
+        'gas',
+        'gasPrice',
+        'input'
+      ])
+      expect(tx.hash).to.be.equal('0x505d58d5b6a38304deaad305ff2d773354cc939afc456562ba6bddbbf201e27f')
+
+      expect(Object.keys(recepeit)).to.be.deep.equal([
+        'transactionHash',
+        'transactionIndex',
+        'blockHash',
+        'blockNumber',
+        'gasUsed',
+        'cumulativeGasUsed',
+        'contractAddress',
+        'logs',
+        'status',
+        'logsBloom'
+      ])
+      expect(recepeit.transactionHash).to.be.equal('0x505d58d5b6a38304deaad305ff2d773354cc939afc456562ba6bddbbf201e27f')
+    })
+
+    it('should return null if the tx hash is invalid or dropped', async () => {
+      const invalidTx = await txUtils.getTransaction(
+        '0xc15c7dda554711eac29d4a983e53aa161dd1bdc6e1d013bb29da1f607916de1'
+      )
+      expect(invalidTx).to.be.equal(null)
+
+      const droppedTx = await txUtils.getTransaction(
+        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969'
+      )
+      expect(droppedTx).to.be.equal(null)
+    })
+  })
+
+  describe('.isTxDropped', function() {
+    it('should wait TRANSACTION_FETCH_DELAY for each retry attempts', async function() {
+      txUtils.TRANSACTION_FETCH_DELAY = 50
+      const retryAttemps = 5
+      const totalTime = 5 * 50
+
+      const begining = Date.now()
+      await txUtils.isTxDropped('0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969', retryAttemps)
+      const end = Date.now()
+      const delay = end - begining
+
+      expect(delay).to.be.within(totalTime, totalTime + 100) // give it 100ms of leway
+    })
+
+    afterEach(() => {
+      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
+    })
+  })
+
+  describe('.waitForCompletion', function() {
+    it('should return a failed tx for a dropped hash', async function() {
+      txUtils.TRANSACTION_FETCH_DELAY = 10
+
+      const droppedTx = await txUtils.waitForCompletion(
+        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969'
+      )
+
+      expect(droppedTx).to.be.deep.equal({
+        hash: '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969',
+        status: txUtils.TRANSACTION_STATUS.failed
+      })
+    })
+
+    it('should return the full transaction after it finishes', async function() {
+      txUtils.TRANSACTION_FETCH_DELAY = 10
+
+      // compiled solidity source code
+      const code =
+        '603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3'
+      const txHash = await eth.wallet.sendTransaction({ data: code })
+      const tx = await txUtils.waitForCompletion(txHash)
+
+      expect(tx.hash).to.be.equal(txHash)
+      expect(tx.recepeit).not.to.be.equal(undefined)
+    })
+
+    afterEach(() => {
+      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
+    })
+  })
+})

--- a/src/ethereum/eth.ts
+++ b/src/ethereum/eth.ts
@@ -3,7 +3,6 @@ import { ethUtils } from './ethUtils'
 import { promisify } from '../utils/index'
 import { Contract } from './Contract'
 import { Wallet } from './wallets/Wallet'
-import { Abi } from './abi'
 
 export type ConnectOptions = {
   /** An array of objects defining contracts or Contract subclasses to use. Check {@link eth#setContracts} */
@@ -149,30 +148,6 @@ export namespace eth {
     }
 
     return contracts[name]
-  }
-
-  /**
-   * Interface for the web3 `getTransaction` method
-   * @param  {string} txId - Transaction id/hash
-   * @return {object}      - An object describing the transaction (if it exists)
-   */
-  export function fetchTxStatus(txId: string): Promise<object> {
-    return promisify(wallet.getWeb3().eth.getTransaction)(txId)
-  }
-
-  /**
-   * Interface for the web3 `getTransactionReceipt` method. It adds the decoded logs to the result (if any)
-   * @param  {string} txId - Transaction id/hash
-   * @return {object} - An object describing the transaction receipt (if it exists) with it's logs
-   */
-  export async function fetchTxReceipt(txId: string): Promise<object> {
-    const receipt = await promisify(wallet.getWeb3().eth.getTransactionReceipt)(txId)
-
-    if (receipt) {
-      receipt.logs = Abi.decodeLogs(receipt.logs)
-    }
-
-    return receipt
   }
 
   export async function sign(payload) {

--- a/src/ethereum/txUtils.ts
+++ b/src/ethereum/txUtils.ts
@@ -6,9 +6,9 @@ import { eth } from './eth'
  * @namespace
  */
 export namespace txUtils {
-  export let DUMMY_TX_ID = '0xdeadbeef'
+  export let DUMMY_TX_ID: string = '0xdeadbeef'
 
-  export let TRANSACTION_FETCH_DELAY = 2 * 1000
+  export let TRANSACTION_FETCH_DELAY: number = 2 * 1000
 
   export let TRANSACTION_STATUS = Object.freeze({
     pending: 'pending',
@@ -40,18 +40,45 @@ export namespace txUtils {
   /**
    * Wait until a transaction finishes by either being mined or failing
    * @param  {string} txId - Transaction id to watch
-   * @return {object} data - Current transaction data. See {@link txUtils#getTransaction}
+   * @param  {number} [retriesOnEmpty] - Number of retries when a transaction status returns empty
+   * @return {Promise<object>} data - Current transaction data. See {@link txUtils#getTransaction}
    */
-  export async function waitForCompletion(txId: string): Promise<any> {
+  export async function waitForCompletion(txId: string, retriesOnEmpty?: number): Promise<any> {
+    const isDropped = await isTxDropped(txId, retriesOnEmpty)
+    if (isDropped) {
+      return { hash: txId, status: TRANSACTION_STATUS.failed }
+    }
+
     while (true) {
       const tx = await getTransaction(txId)
 
-      if (isPending(tx) || !tx.recepeit) {
-        await sleep(TRANSACTION_FETCH_DELAY)
-      } else {
+      if (!isPending(tx) && tx.recepeit) {
         return tx
       }
+
+      await sleep(TRANSACTION_FETCH_DELAY)
     }
+  }
+
+  /*
+   * Wait retryAttemps*TRANSACTION_FETCH_DELAY for a transaction status to be in the mempool
+   * @param  {string} txId - Transaction id to watch
+   * @param  {number} [retryAttemps=15] - Number of retries when a transaction status returns empty
+   * @return {Promise<boolean>}
+   */
+  export async function isTxDropped(txId: string, retryAttemps: number = 15): Promise<boolean> {
+    while (retryAttemps > 0) {
+      const tx = await getTransaction(txId)
+
+      if (tx !== null) {
+        return false
+      }
+
+      retryAttemps -= 1
+      await sleep(TRANSACTION_FETCH_DELAY)
+    }
+
+    return true
   }
 
   /**
@@ -66,7 +93,7 @@ export namespace txUtils {
       eth.wallet.getTransactionReceipt(txId)
     ])
 
-    return { ...tx, recepeit }
+    return tx ? { ...tx, recepeit } : null
   }
 
   /**

--- a/src/ethereum/wallets/Wallet.ts
+++ b/src/ethereum/wallets/Wallet.ts
@@ -92,6 +92,10 @@ export abstract class Wallet {
     return promisify(this.getWeb3().eth.estimateGas)(options)
   }
 
+  async sendTransaction(transactionObject: any) {
+    return promisify(this.getWeb3().eth.sendTransaction)(transactionObject)
+  }
+
   async getContract(abi: any[]) {
     return this.getWeb3().eth.contract(abi)
   }
@@ -105,11 +109,16 @@ export abstract class Wallet {
     return promisify(this.getWeb3().eth.getTransaction)(txId)
   }
 
+  /**
+   * Interface for the web3 `getTransactionReceipt` method. It adds the decoded logs to the result (if any)
+   * @param  {string} txId - Transaction id/hash
+   * @return {object} - An object describing the transaction receipt (if it exists) with it's logs
+   */
   async getTransactionReceipt(txId: string): Promise<TxReceipt> {
     const receipt = await promisify(this.getWeb3().eth.getTransactionReceipt)(txId)
 
-    if (receipt && receipt['logs']) {
-      receipt['logs'] = Abi.decodeLogs(receipt['logs'])
+    if (receipt && receipt.logs) {
+      receipt.logs = Abi.decodeLogs(receipt.logs)
     }
 
     return receipt


### PR DESCRIPTION
also removes repeated code for fetching transaction statuses.

The idea is to make `waitForCompletion` aware of dropped transactions, which return as `null`, but give it some time to wait in case there's congestion (hence the `retriesOnEmpty`).

I'm not in love with the impl, comments are welcomed