### PR TITLE
feat: dont fail in connect using only a providerUrl

### DIFF
--- a/specs/deployContract.ts
+++ b/specs/deployContract.ts
@@ -1,9 +1,11 @@
+import { Wallet } from '../dist/ethereum/wallets/Wallet'
+
 export type Artifact = {
-  abi: object
+  abi: any[]
   bytecode: string
 }
 
-export async function deployContract(wallet, name: string, contract: Artifact) {
+export async function deployContract(wallet: Wallet, name: string, contract: Artifact) {
   const account = await wallet.getAccount()
 
   const newContract = await wallet.getContract(contract.abi)

--- a/specs/remoteProvider.spec.ts
+++ b/specs/remoteProvider.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai'
+import { eth, txUtils } from '../dist'
+import { MANAToken } from '../dist/contracts'
+
+const MainnetMANAAddress = '0x0f5d2fb29fb7d3cfee444a200298f468908cc942'
+const mainnetFailedTransaction = '0x8f9369340bcd100b260a872b34e79f7b441e694db89c533310a77458d264fe18'
+const mainnetInvalidTransaction = '0x1231231212312312123123121231231212312312123123121231231212312312'
+const mainnetValidTransaction = '0xd8d05c253a8959486524e31ba5664905b803ad24550befc119d9ba56d204bb28'
+
+describe('ETH using url provider (mainnet)', function() {
+  const provider = 'https://mainnet.infura.io'
+
+  it('should call .connect({}) and it works', async function() {
+    this.timeout(10000)
+    const r = await eth.connect({ provider })
+    console.log('connected')
+    expect(r).to.eq(true)
+  })
+
+  it('should throw trying to get an address', () => {
+    expect(() => eth.getAddress()).to.throw()
+  })
+
+  let MANAFacade: MANAToken
+
+  it('instantiates a mana contract', async function() {
+    this.timeout(10000)
+
+    MANAFacade = new MANAToken(MainnetMANAAddress)
+
+    await eth.setContracts([MANAFacade])
+
+    expect(MANAFacade.instance).to.not.eq(null)
+  })
+
+  it('should get 0 mana balance by default', async function() {
+    this.timeout(10000)
+    {
+      const balance = await MANAFacade.balanceOf(MainnetMANAAddress)
+      expect(balance.toString()).not.eq('0')
+      expect(typeof balance).eq('number')
+    }
+    {
+      const balance = await MANAFacade.balanceOf('0x123')
+      expect(balance.toString()).eq('0')
+    }
+  })
+
+  it('should fail by invoking an unexistent method', async function() {
+    this.timeout(10000)
+    expect(() => MANAFacade.sendCall('asdasd')).to.throw()
+  })
+
+  it('should return null if the tx hash is invalid', async function() {
+    this.timeout(30000)
+    const invalidTx = await txUtils.getTransaction(mainnetInvalidTransaction)
+    expect(invalidTx).to.be.equal(null)
+  })
+
+  it('should work and identify failed transactions', async function() {
+    this.timeout(30000)
+    const failedTx = await txUtils.getTransaction(mainnetFailedTransaction)
+
+    expect(txUtils.isFailure(failedTx)).to.be.equal(true)
+  })
+
+  it('should get the status of a transaction', async function() {
+    this.timeout(10000)
+    const successTx = await txUtils.getTransaction(mainnetValidTransaction)
+    expect(successTx.hash).to.eq(mainnetValidTransaction)
+  })
+})

--- a/src/ethereum/Contract.ts
+++ b/src/ethereum/Contract.ts
@@ -11,7 +11,6 @@ export abstract class Contract<T = any> {
   /**
    * @param  {string} [address] - Address of the contract. If it's undefined, it'll use the result of calling {@link Contract#getDefaultAddress}
    * @param  {object} [abi]     - Object describing the contract (compile result). If it's undefined, it'll use the result of calling {@link Contract#getDefaultAbi}
-   * @return {Contract} instance
    */
   constructor(address: string, abi: object) {
     this.setAddress(address)
@@ -25,7 +24,7 @@ export abstract class Contract<T = any> {
    * @param  {string} address
    * @return {boolean}
    */
-  static isEmptyAddress(address) {
+  static isEmptyAddress(address: string): boolean {
     return !address || address === '0x0000000000000000000000000000000000000000' || address === '0x'
   }
 
@@ -53,7 +52,7 @@ export abstract class Contract<T = any> {
    * Get the contract events from the abi
    * @return {Array<string>} - events
    */
-  getEvents() {
+  getEvents(): Array<string> {
     return Abi.new(this.abi).getEvents()
   }
 
@@ -92,6 +91,9 @@ export abstract class Contract<T = any> {
    * @return {Promise} - promise that resolves when the transaction does
    */
   sendTransaction(method: string, ...args) {
+    if (!this.instance) {
+      throw new Error(`The contract "${this.getContractName()}" was not initialized with a provider`)
+    }
     if (!this.instance[method]) {
       throw new Error(`${this.getContractName()}#sendTransaction: Unknown method ${method}`)
     }
@@ -108,6 +110,9 @@ export abstract class Contract<T = any> {
    * @return {Promise} - promise that resolves when the call does
    */
   sendCall(prop: string, ...args) {
+    if (!this.instance) {
+      throw new Error(`The contract "${this.getContractName()}" was not initialized with a provider`)
+    }
     if (!this.instance[prop]) {
       throw new Error(`${this.getContractName()}#sendCall: Unknown method ${prop}`)
     }

--- a/src/ethereum/txUtils.ts
+++ b/src/ethereum/txUtils.ts
@@ -1,5 +1,6 @@
 import { sleep } from '../utils'
 import { eth } from './eth'
+import { TxReceipt, TxStatus } from './wallets/Wallet'
 
 /**
  * Some utility functions to work with Ethereum transactions.
@@ -87,7 +88,8 @@ export namespace txUtils {
    * @return {object} data - Current transaction data. See {@link https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransaction}
    * @return {object.recepeit} transaction - Transaction recepeit
    */
-  export async function getTransaction(txId: string) {
+  // prettier-ignore
+  export async function getTransaction(txId: string): Promise<{ recepeit: TxReceipt } & TxStatus> {
     const [tx, recepeit] = await Promise.all([
       eth.wallet.getTransactionStatus(txId),
       eth.wallet.getTransactionReceipt(txId)

--- a/src/ethereum/wallets/LedgerWallet.ts
+++ b/src/ethereum/wallets/LedgerWallet.ts
@@ -40,23 +40,26 @@ export class LedgerWallet extends Wallet {
     }
 
     const transport = await TransportU2F.open(null, 2)
-    const ledger = new Eth(transport)
 
-    this.ledger = ledger
-
-    // FireFox hangs on indefinetly on `getAccounts`, so the second promise acts as a timeout
-    const accounts = await Promise.race([
-      this.getAccounts(),
-      sleep(2000).then(() => Promise.reject({ message: 'Timed out trying to connect to ledger' }))
-    ])
+    this.ledger = new Eth(transport)
 
     this.engine = new ProviderEngine()
 
     const provider = await this.getProvider(providerUrl, networkId)
     this.web3 = new Web3(provider)
 
-    if (!this.account) {
-      this.setAccount(accounts[0])
+    try {
+      // FireFox hangs on indefinetly on `getAccounts`, so the second promise acts as a timeout
+      const accounts = await Promise.race([
+        this.getAccounts(),
+        sleep(2000).then(() => Promise.reject({ message: 'Timed out trying to connect to ledger' }))
+      ])
+
+      if (accounts[0]) {
+        this.setAccount(accounts[0])
+      }
+    } catch {
+      // do nothing
     }
   }
 

--- a/src/ethereum/wallets/NodeWallet.ts
+++ b/src/ethereum/wallets/NodeWallet.ts
@@ -7,7 +7,6 @@ declare var window
 
 export class NodeWallet extends Wallet {
   web3: any
-  account: any
 
   getType(): string {
     return 'node'
@@ -22,11 +21,9 @@ export class NodeWallet extends Wallet {
 
     this.web3 = new Web3(theProvider)
 
-    if (!this.account) {
-      const accounts = await this.getAccounts()
-      if (accounts.length === 0) {
-        throw new Error('Could not connect to web3')
-      }
+    const accounts = await this.getAccounts()
+
+    if (accounts.length !== 0) {
       this.setAccount(accounts[0])
     }
   }
@@ -36,7 +33,7 @@ export class NodeWallet extends Wallet {
    * @param  {string} [providerURL="http://localhost:8545"] - URL for an HTTP provider in case the browser provider is not present
    * @return {object} The web3 provider
    */
-  getProvider(providerUrl = 'http://localhost:8545') {
+  getProvider(providerUrl: string = 'http://localhost:8545') {
     if (typeof window !== 'undefined' && window.web3 && window.web3.currentProvider) {
       return window.web3.currentProvider
     } else {
@@ -49,8 +46,9 @@ export class NodeWallet extends Wallet {
   }
 
   async sign(message: string) {
+    const account = this.getAccount()
     const sign = this.web3.personal.sign.bind(this.web3.personal)
-    return Contract.sendTransaction(sign, message, this.account)
+    return Contract.sendTransaction(sign, message, account)
   }
 
   async recover(message: string, signature: string) {

--- a/src/ethereum/wallets/Wallet.ts
+++ b/src/ethereum/wallets/Wallet.ts
@@ -14,13 +14,26 @@ export interface TxReceipt {
   logsBloom: string
 }
 
+export type TxStatus = {
+  hash: string
+  nonce: number
+  blockHash: string
+  transactionIndex: number
+  from: string
+  to: string
+  value: any // BigNumber
+  gas: number
+  gasPrice: any // BigNumber
+  input: string
+}
+
 // Interface
 export abstract class Wallet {
   type = this.getType()
   web3 = null
   derivationPath = null
 
-  constructor(public account?: string) {
+  constructor(private account?: string) {
     // stub
   }
 
@@ -35,6 +48,9 @@ export abstract class Wallet {
   }
 
   getAccount() {
+    if (!this.account) {
+      throw new Error("The current wallet/provider doesn't have any linked account")
+    }
     return this.account
   }
 
@@ -105,7 +121,7 @@ export abstract class Wallet {
    * @param  {string} txId - Transaction id/hash
    * @return {object}      - An object describing the transaction (if it exists)
    */
-  async getTransactionStatus(txId: string) {
+  async getTransactionStatus(txId: string): Promise<TxStatus> {
     return promisify(this.getWeb3().eth.getTransaction)(txId)
   }
 


### PR DESCRIPTION
The client is using this inside a WebWorker, that means we have no instance of web3/metamask there, and we only rely on an URL provider