### PR TITLE
feat: override getPendingAmount to view

### DIFF
--- a/src/contracts/artifacts/RCNEngine.json
+++ b/src/contracts/artifacts/RCNEngine.json
@@ -418,7 +418,7 @@
       "name": "getPendingAmount",
       "outputs": [{ "name": "", "type": "uint256" }],
       "payable": false,
-      "stateMutability": "nonpayable",
+      "stateMutability": "view",
       "type": "function"
     },
     {


### PR DESCRIPTION
At [NanoLoanEngine Ripio contract](https://github.com/ripio/rcn-mortgages/blob/master/contracts/utils/test/ripiocredit/NanoLoanEngine.sol#L750) there is a contract method we need to call in order to get the loan's outstanding amount. As the method is not a `view` cause change the contract state, we need to make a workaround changing the ABI until we decide to make the **interest** math on our side