### PR TITLE
feat: better dropped transactions

### DIFF
--- a/specs/txUtils.spec.ts
+++ b/specs/txUtils.spec.ts
@@ -92,7 +92,8 @@ describe('txUtils tests', () => {
 
       expect(droppedTx).to.be.deep.equal({
         hash: '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969',
-        status: txUtils.TRANSACTION_STATUS.failed
+        status: txUtils.TRANSACTION_STATUS.failed,
+        isDropped: true
       })
     })
 


### PR DESCRIPTION
This PR adds an extra argument `retriesOnEmpty` to `.getConfirmedTransaction` that allows us to customize the retries of the underlying `.waitForCompletion`.

Also this PR makes this method throw a different error message when a transaction is dropped than when it fails, to make our lifes easier while debugging and looking thru logs or segment events.