### PR TITLE
fix: check for null tx

### DIFF
--- a/src/ethereum/txUtils.ts
+++ b/src/ethereum/txUtils.ts
@@ -57,7 +57,7 @@ export namespace txUtils {
     while (true) {
       const tx = await getTransaction(txId)
 
-      if (!isPending(tx) && tx.recepeit) {
+      if (tx && !isPending(tx) && tx.recepeit) {
         return tx
       }
 


### PR DESCRIPTION
The following code throws many times:

```ts
const tx = await getTransaction(txId)

if (!isPending(tx) && tx.recepeit) {
```

Because when we get a transaction like this:

```js
const tx = await getTransaction(txId)
```

The value of `tx` can be null because:

```ts
export async function getTransaction(txId: string): Promise<{ recepeit: TxReceipt } & TxStatus> {
  const [tx, recepeit] = await Promise.all([
    eth.wallet.getTransactionStatus(txId),
    eth.wallet.getTransactionReceipt(txId)
  ])

  return tx ? { ...tx, recepeit } : null
}
```

And then when we do:

```ts
!isPending(tx) && tx.recepeit
```

`isPending` returns `null`:

```ts
export function isPending(tx) {
  return tx && (tx.blockNumber === null || tx.status === TRANSACTION_STATUS.pending)
}
```

Then `!isPending(tx)` evaluates to `true` and the following expression evaluated is `tx.recepeit` which throws `Cannot read property 'recepeit' of null` 💥💥💥

This PR fixes that.

Also, is it okay that the property is called `recepeit` and not `receipt` ? I searched it and it's like that all over the library...