### PR TITLE
feat: added dropped transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-eth",
-  "version": "0.0.0-development",
+  "version": "5.0.0-rc6",
   "description": "Common functionality between the different Decentraland projects",
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.js",
@@ -25,14 +25,8 @@
     "type": "git",
     "url": "https://github.com/decentraland/decentraland-eth.git"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "common",
-    "modules",
-    "decentraland"
-  ],
+  "files": ["dist"],
+  "keywords": ["common", "modules", "decentraland"],
   "author": "Decentraland",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-eth",
-  "version": "5.0.0-rc6",
+  "version": "0.0.0-development",
   "description": "Common functionality between the different Decentraland projects",
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/specs/Contracts.spec.ts
+++ b/specs/Contracts.spec.ts
@@ -84,7 +84,8 @@ function doTest() {
     expect(typeof txRecipt.contractAddress).to.eq('string')
     expect(txRecipt.contractAddress.length).to.be.greaterThan(0)
 
-    const x = await txUtils.getTransaction(contract.transactionHash)
+    /* tslint:disable-next-line:no-unnecessary-type-assertion */
+    const x = (await txUtils.getTransaction(contract.transactionHash)) as txUtils.ConfirmedTransaction
     expect(typeof x).eq('object')
     expect(x.hash).eq(contract.transactionHash)
     expect(typeof x.receipt).eq('object')

--- a/specs/Wallet.spec.ts
+++ b/specs/Wallet.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai'
+import { NodeConnectionFactory } from './NodeConnectionFactory'
+import { eth, txUtils } from '../dist'
+
+describe('Wallet tests', () => {
+  const nodeConnectionFactory = new NodeConnectionFactory()
+  let provider
+
+  before(() => {
+    provider = nodeConnectionFactory.createProvider()
+    return eth.connect({ provider })
+  })
+
+  describe('.getTransactionsByAccount', function() {
+    it('should return the right amount of txs', async function() {
+      const account = eth.getAccount()
+
+      const txId = await eth.wallet.sendTransaction({ from: account })
+      await txUtils.getConfirmedTransaction(txId)
+      const txs = await eth.wallet.getTransactionsByAccount(account)
+      expect(txs.length).to.be.equal(1)
+
+      const txId2 = await eth.wallet.sendTransaction({ from: account })
+      await txUtils.getConfirmedTransaction(txId2)
+      const txs2 = await eth.wallet.getTransactionsByAccount(account)
+      expect(txs2.length).to.be.equal(2)
+    })
+  })
+})

--- a/specs/remoteProvider.spec.ts
+++ b/specs/remoteProvider.spec.ts
@@ -57,11 +57,12 @@ describe('ETH using url provider (mainnet)', function() {
     expect(invalidTx).to.be.equal(null)
   })
 
-  it('should work and identify failed transactions', async function() {
+  it('should work and identify reverted transactions', async function() {
     this.timeout(30000)
-    const failedTx = await txUtils.getTransaction(mainnetFailedTransaction)
+    /* tslint:disable-next-line:no-unnecessary-type-assertion */
+    const failedTx = (await txUtils.getTransaction(mainnetFailedTransaction)) as txUtils.RevertedTransaction
 
-    expect(txUtils.isFailure(failedTx)).to.be.equal(true)
+    expect(failedTx.type).to.be.equal('reverted')
   })
 
   it('should get the status of a transaction', async function() {

--- a/specs/txUtils.spec.ts
+++ b/specs/txUtils.spec.ts
@@ -83,17 +83,17 @@ describe('txUtils tests', () => {
   })
 
   describe('.waitForCompletion', function() {
-    it('should return a failed tx for a dropped hash', async function() {
+    it('should return a dropped tx for a dropped hash', async function() {
       txUtils.TRANSACTION_FETCH_DELAY = 10
 
       const droppedTx = await txUtils.waitForCompletion(
-        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969'
+        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969',
+        10
       )
 
       expect(droppedTx).to.be.deep.equal({
         hash: '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969',
-        status: txUtils.TRANSACTION_STATUS.failed,
-        isDropped: true
+        status: txUtils.TRANSACTION_STATUS.dropped
       })
     })
 
@@ -107,7 +107,42 @@ describe('txUtils tests', () => {
       const tx = await txUtils.waitForCompletion(txHash)
 
       expect(tx.hash).to.be.equal(txHash)
-      expect(tx.receipt).not.to.be.equal(undefined)
+      expect(tx.status).to.be.equal(txUtils.TRANSACTION_STATUS.confirmed)
+    })
+
+    afterEach(() => {
+      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
+    })
+  })
+
+  describe('.getConfirmedTransaction', function() {
+    it('should throw for a dropped hash', async function() {
+      txUtils.TRANSACTION_FETCH_DELAY = 10
+
+      async function letsGetThatConfirmedTx() {
+        try {
+          await txUtils.getConfirmedTransaction('0xThisIsNotAValidHash,Sir', [], 1)
+          return '🦄'
+        } catch (error) {
+          return '💥'
+        }
+      }
+
+      const result = await letsGetThatConfirmedTx()
+      expect(result).to.be.equal('💥')
+    })
+
+    it('should return the full transaction after it finishes', async function() {
+      txUtils.TRANSACTION_FETCH_DELAY = 10
+
+      // compiled solidity source code
+      const code =
+        '603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3'
+      const txHash = await eth.wallet.sendTransaction({ data: code })
+      const tx = await txUtils.waitForCompletion(txHash)
+
+      expect(tx.hash).to.be.equal(txHash)
+      expect(tx.status).be.equal(txUtils.TRANSACTION_STATUS.confirmed)
     })
 
     afterEach(() => {

--- a/specs/txUtils.spec.ts
+++ b/specs/txUtils.spec.ts
@@ -4,7 +4,6 @@ import { deployContract } from './deployContract'
 import { eth, txUtils } from '../dist'
 
 describe('txUtils tests', () => {
-  const DEFAULT_FETCH_DELAY = txUtils.TRANSACTION_FETCH_DELAY
   const nodeConnectionFactory = new NodeConnectionFactory()
   let provider
 
@@ -14,13 +13,17 @@ describe('txUtils tests', () => {
   })
 
   describe('.getTransaction', function() {
-    it('should return the transaction status and its receipt', async function() {
+    it('should return the confirmed transaction status and its receipt', async function() {
       this.timeout(100000)
 
       const contract = await deployContract(eth.wallet, 'MANA', require('./fixtures/MANAToken.json'))
-      const { receipt, ...tx } = await txUtils.getTransaction(contract.transactionHash)
+      /* tslint:disable-next-line:no-unnecessary-type-assertion */
+      const { receipt, ...tx } = (await txUtils.getTransaction(
+        contract.transactionHash
+      )) as txUtils.ConfirmedTransaction
 
       expect(Object.keys(tx)).to.be.deep.equal([
+        'type',
         'hash',
         'nonce',
         'blockHash',
@@ -50,103 +53,18 @@ describe('txUtils tests', () => {
       expect(receipt.transactionHash).to.be.equal('0x505d58d5b6a38304deaad305ff2d773354cc939afc456562ba6bddbbf201e27f')
     })
 
-    it('should return null if the tx hash is invalid or dropped', async () => {
-      const invalidTx = await txUtils.getTransaction(
-        '0xc15c7dda554711eac29d4a983e53aa161dd1bdc6e1d013bb29da1f607916de1'
-      )
-      expect(invalidTx).to.be.equal(null)
-
-      const droppedTx = await txUtils.getTransaction(
-        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969'
-      )
-      expect(droppedTx).to.be.equal(null)
-    })
-  })
-
-  describe('.isTxDropped', function() {
-    it('should wait TRANSACTION_FETCH_DELAY for each retry attempts', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 50
-      const retryAttemps = 5
-      const totalTime = 5 * 50
-
-      const begining = Date.now()
-      await txUtils.isTxDropped('0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969', retryAttemps)
-      const end = Date.now()
-      const delay = end - begining
-
-      expect(delay).to.be.within(totalTime, totalTime + 100) // give it 100ms of leway
-    })
-
-    afterEach(() => {
-      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
-    })
-  })
-
-  describe('.waitForCompletion', function() {
-    it('should return a dropped tx for a dropped hash', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 10
-
-      const droppedTx = await txUtils.waitForCompletion(
-        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969',
-        10
-      )
-
-      expect(droppedTx).to.be.deep.equal({
-        hash: '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969',
-        status: txUtils.TRANSACTION_STATUS.dropped
-      })
-    })
-
-    it('should return the full transaction after it finishes', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 10
-
-      // compiled solidity source code
-      const code =
-        '603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3'
-      const txHash = await eth.wallet.sendTransaction({ data: code })
-      const tx = await txUtils.waitForCompletion(txHash)
-
-      expect(tx.hash).to.be.equal(txHash)
-      expect(tx.status).to.be.equal(txUtils.TRANSACTION_STATUS.confirmed)
-    })
-
-    afterEach(() => {
-      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
+    it('should return null for an unknown transaction', async function() {
+      const tx = await txUtils.getTransaction('0xfaceb00c')
+      expect(tx).to.be.null // tslint:disable-line
     })
   })
 
   describe('.getConfirmedTransaction', function() {
-    it('should throw for a dropped hash', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 10
-
-      async function letsGetThatConfirmedTx() {
-        try {
-          await txUtils.getConfirmedTransaction('0xThisIsNotAValidHash,Sir', [], 1)
-          return '🦄'
-        } catch (error) {
-          return '💥'
-        }
-      }
-
-      const result = await letsGetThatConfirmedTx()
-      expect(result).to.be.equal('💥')
-    })
-
-    it('should return the full transaction after it finishes', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 10
-
-      // compiled solidity source code
-      const code =
-        '603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3'
-      const txHash = await eth.wallet.sendTransaction({ data: code })
-      const tx = await txUtils.waitForCompletion(txHash)
-
-      expect(tx.hash).to.be.equal(txHash)
-      expect(tx.status).be.equal(txUtils.TRANSACTION_STATUS.confirmed)
-    })
-
-    afterEach(() => {
-      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
+    it('should return the confirmed transaction', async function() {
+      const account = eth.getAccount()
+      const txId = await eth.wallet.sendTransaction({ from: account })
+      const tx = await txUtils.getConfirmedTransaction(txId)
+      expect(tx.type).to.be.equal('confirmed')
     })
   })
 })

--- a/src/ethereum/eth.ts
+++ b/src/ethereum/eth.ts
@@ -96,6 +96,11 @@ export namespace eth {
     return getAccount()
   }
 
+  export async function getCurrentNonce(): Promise<number> {
+    const address = getAddress()
+    return promisify(wallet.getWeb3().eth.getTransactionCount)(address)
+  }
+
   export function getAccount() {
     return wallet.getAccount()
   }
@@ -150,7 +155,7 @@ export namespace eth {
     return contracts[name]
   }
 
-  export async function sign(payload): Promise<{message: string; signature: string}> {
+  export async function sign(payload): Promise<{ message: string; signature: string }> {
     const message = ethUtils.toHex(payload)
     const signature = await wallet.sign(message)
     return { message, signature }

--- a/src/ethereum/txUtils.ts
+++ b/src/ethereum/txUtils.ts
@@ -1,6 +1,6 @@
-import { sleep } from '../utils'
 import { eth } from './eth'
-import { TxReceipt, TxStatus } from './wallets/Wallet'
+import { TransactionReceipt, TransactionStatus } from './wallets/Wallet'
+import { sleep } from '../utils'
 
 /**
  * Some utility functions to work with Ethereum transactions.
@@ -11,177 +11,151 @@ export namespace txUtils {
 
   export let TRANSACTION_FETCH_DELAY: number = 2 * 1000
 
-  export let TRANSACTION_STATUS = Object.freeze({
-    pending: 'pending',
-    confirmed: 'confirmed',
-    failed: 'failed',
+  export type TransactionTypes = {
+    queued: 'queued'
     dropped: 'dropped'
+    replaced: 'replaced'
+    pending: 'pending'
+    reverted: 'reverted'
+    confirmed: 'confirmed'
+  }
+
+  export let TRANSACTION_TYPES: TransactionTypes = Object.freeze({
+    queued: 'queued' as 'queued',
+    dropped: 'dropped' as 'dropped',
+    replaced: 'replaced' as 'replaced',
+    pending: 'pending' as 'pending',
+    reverted: 'reverted' as 'reverted',
+    confirmed: 'confirmed' as 'confirmed'
   })
 
-  export type MinedTransaction = { receipt: TxReceipt } & TxStatus
-  export type DroppedTransaction = { status: string; hash: string }
-
-  export class DroppedTransactionError extends Error {
-    public tx: DroppedTransaction
-    public dropped = true
-    public status = TRANSACTION_STATUS.dropped
-    constructor(tx: DroppedTransaction, message?: string) {
-      super(message) // 'Error' breaks prototype chain here
-      this.tx = tx
-      Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
-    }
+  export type DroppedTransaction = {
+    type: TransactionTypes['dropped']
+    hash: string
+    nonce: number
   }
 
-  export class FailedTransactionError extends Error {
-    public tx: MinedTransaction
-    public failed: boolean = true
-    public status: string = TRANSACTION_STATUS.failed
-    constructor(tx: MinedTransaction, message?: string) {
-      super(message) // 'Error' breaks prototype chain here
-      this.tx = tx
-      Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
-    }
+  export type ReplacedTransaction = {
+    type: TransactionTypes['replaced']
+    hash: string
+    nonce: number
   }
 
-  /**
-   * Waits until the transaction finishes. Returns if it was successfull.
-   * Throws if the transaction fails or if it lacks any of the supplied events
-   * @param  {string} txId - Transaction id to watch
-   * @param  {Array<string>|string} events - Events to watch. See {@link txUtils#getLogEvents}
-   * @param  {number} [retriesOnEmpty] - Number of retries when a transaction status returns empty
-   * @return {object} data - Current transaction data. See {@link txUtils#getTransaction}
-   */
-  export async function getConfirmedTransaction(txId: string, events: string[], retriesOnEmpty?: number) {
-    const tx = await waitForCompletion(txId, retriesOnEmpty)
+  export type QueuedTransaction = {
+    type: TransactionTypes['queued']
+    hash: string
+    nonce: number
+  }
 
-    if (!tx) {
-      throw new Error(`Transaction "${txId}" falsy: ${tx}`)
+  export type PendingTransaction = TransactionStatus & {
+    type: TransactionTypes['pending']
+  }
+
+  export type RevertedTransaction = TransactionStatus & {
+    type: TransactionTypes['reverted']
+  }
+
+  export type ConfirmedTransaction = TransactionStatus & {
+    type: TransactionTypes['confirmed']
+    receipt: TransactionReceipt
+  }
+
+  export type Transaction =
+    | DroppedTransaction
+    | ReplacedTransaction
+    | QueuedTransaction
+    | PendingTransaction
+    | ConfirmedTransaction
+    | RevertedTransaction
+
+  export async function getTransaction(hash: string): Promise<Transaction> {
+    const status = await eth.wallet.getTransactionStatus(hash)
+
+    // not found
+    if (status == null) {
+      return null
     }
 
-    if (isDropped(tx)) {
-      throw new DroppedTransactionError(tx as DroppedTransaction, `Transaction "${txId}" dropped`)
+    if (status.blockNumber == null) {
+      const currentNonce = await eth.getCurrentNonce()
+
+      // replaced
+      if (status.nonce < currentNonce) {
+        const tx: ReplacedTransaction = {
+          hash,
+          type: 'replaced',
+          nonce: status.nonce
+        }
+        return tx
+      }
+
+      // queued
+      if (status.nonce > currentNonce) {
+        const tx: QueuedTransaction = {
+          hash,
+          type: 'queued',
+          nonce: status.nonce
+        }
+        return tx
+      }
+
+      // pending
+      const tx: PendingTransaction = {
+        type: 'pending',
+        ...status
+      }
+      return tx
     }
 
-    if (isFailure(tx)) {
-      throw new FailedTransactionError(tx as MinedTransaction, `Transaction "${txId}" failed`)
+    const receipt = await eth.wallet.getTransactionReceipt(hash)
+
+    // reverted
+    if (receipt == null || receipt.status === '0x0') {
+      const tx: RevertedTransaction = {
+        type: 'reverted',
+        ...status
+      }
+      return tx
     }
 
-    if (!hasLogEvents(tx, events)) {
-      throw new Error(`Missing events for transaction "${txId}": ${events}`)
+    // confirmed
+    const tx: ConfirmedTransaction = {
+      type: 'confirmed',
+      ...status,
+      receipt
     }
-
     return tx
   }
 
-  /**
-   * Wait until a transaction finishes by either being mined or failing
-   * @param  {string} txId - Transaction id to watch
-   * @param  {number} [retriesOnEmpty] - Number of retries when a transaction status returns empty, if not provided it will retry indefinitely
-   * @return {Promise<object>} data - Current transaction data. See {@link txUtils#getTransaction}
-   */
-  export async function waitForCompletion(
-    txId: string,
-    retriesOnEmpty?: number
-  ): Promise<MinedTransaction | DroppedTransaction> {
-    let retries = 0
+  export async function getConfirmedTransaction(hash: string, events: string[] = []): Promise<ConfirmedTransaction> {
     while (true) {
-      const tx = await getTransaction(txId)
-
-      if (tx && !isPending(tx) && tx.receipt) {
-        if (isFailure(tx)) {
-          return { ...tx, status: TRANSACTION_STATUS.failed }
-        } else {
-          return { ...tx, status: TRANSACTION_STATUS.confirmed }
+      const tx = await getTransaction(hash)
+      if (tx != null) {
+        switch (tx.type) {
+          case 'reverted':
+          case 'dropped':
+          case 'replaced':
+            throw new Error(`Error: transaction ${tx.type}`)
+          case 'confirmed': {
+            if (!hasLogEvents(tx, events)) {
+              throw new Error(`Missing events for transaction "${hash}": ${events}`)
+            }
+            return tx
+          }
         }
       }
-
-      retries++
-      if (!isNaN(retriesOnEmpty) && retries > retriesOnEmpty) {
-        return { hash: txId, status: TRANSACTION_STATUS.dropped }
-      }
-
       await sleep(TRANSACTION_FETCH_DELAY)
     }
   }
 
-  /*
-   * Wait retryAttemps*TRANSACTION_FETCH_DELAY for a transaction status to be in the mempool
-   * @param  {string} txId - Transaction id to watch
-   * @param  {number} [retryAttemps=15] - Number of retries when a transaction status returns empty
-   * @return {Promise<boolean>}
-   */
-  export async function isTxDropped(txId: string, retryAttemps: number = 15): Promise<boolean> {
-    while (retryAttemps > 0) {
-      const tx = await getTransaction(txId)
-
-      if (tx !== null) {
-        return false
-      }
-
-      retryAttemps -= 1
-      await sleep(TRANSACTION_FETCH_DELAY)
-    }
-
-    return true
-  }
-
-  /**
-   * Get the transaction status and receipt
-   * @param  {string} txId - Transaction id
-   * @return {object} data - Current transaction data. See {@link https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransaction}
-   * @return {object.receipt} transaction - Transaction receipt
-   */
-  // prettier-ignore
-  export async function getTransaction(txId: string): Promise<MinedTransaction> {
-    const [tx, receipt] = await Promise.all([
-      eth.wallet.getTransactionStatus(txId),
-      eth.wallet.getTransactionReceipt(txId)
-    ])
-
-    return tx ? { ...tx, receipt } : null
-  }
-
-  /**
-   * Expects the result of getTransaction's geth command and returns true if the transaction is still pending.
-   * It'll also check for a pending status prop against {@link txUtils#TRANSACTION_STATUS}
-   * @param {object} tx - The transaction object
-   * @return boolean
-   */
-  export function isPending(tx) {
-    return tx && (tx.blockNumber === null || tx.status === TRANSACTION_STATUS.pending)
-  }
-
-  /**
-   * Expects the result of getTransactionReceipt's geth command and returns true if the transaction failed.
-   * It'll also check for a failed status prop against {@link txUtils#TRANSACTION_STATUS}
-   * @param {object} tx - The transaction object
-   * @return boolean
-   */
-  export function isFailure(tx) {
-    return tx && (!tx.receipt || tx.receipt.status === '0x0' || tx.status === TRANSACTION_STATUS.failed)
-  }
-
-  /**
-   * Checks for a dropped status prop against {@link txUtils#TRANSACTION_STATUS}
-   * @param {object} tx - The transaction object
-   * @return boolean
-   */
-  export function isDropped(tx) {
-    return tx && tx.status === TRANSACTION_STATUS.dropped
-  }
-
-  /**
-   * Returns true if a transaction contains an event
-   * @param {Array<object>} tx - Transaction with a decoded receipt
-   * @param {Array<string>|string} eventNames - A string or array of strings with event names you want to search for
-   * @return boolean
-   */
-  export function hasLogEvents(tx, eventNames: string[]) {
+  export function hasLogEvents(tx, eventNames: string[] = []) {
+    if (!tx) return false
     if (!eventNames || eventNames.length === 0) return true
     if (!tx.recepit) return false
 
     if (!Array.isArray(eventNames)) eventNames = [eventNames]
 
-    return tx.receipt.filter(log => log && log.name).every(log => eventNames.includes(log.name))
+    const eventsFromLogs = tx.receipt.filter(log => log && log.name).map(log => log.name)
+    return eventNames.every(eventName => eventsFromLogs.includes(eventName))
   }
 }

--- a/src/ethereum/wallets/Wallet.ts
+++ b/src/ethereum/wallets/Wallet.ts
@@ -15,6 +15,7 @@ export interface TxReceipt {
 }
 
 export type TxStatus = {
+  status: string
   hash: string
   nonce: number
   blockHash: string


### PR DESCRIPTION
This PR adds a fourth status to the transactions: `dropped`.  Currently we make no difference between failed and dropped transactions so we can't give proper feedback and instructions to the users on what to do (ie. if we knew a transaction was dropped we could point them to retry the transaction with a higher fee).

* `waitForCompletion`: this will always return a transaction, that can be `success`, `failed` or `dropped` (before it only returned `success` or `failed` transactions).

* `getConfirmedTransaction`: this function works the same as before, returning a promise of the `confirmed` transaction and throwing otherwise, but the difference is that now there are two types of errors: `FailedTransactionError` and `DroppedTransactionError`. The former includes a `MinedTransaction` (which contains a receipt) the latter includes a `DroppedTransaction` (only hash and status).

I added tests for the dropped/failed scenarios