### PR TITLE
feat: improved transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,8 @@
     "type": "git",
     "url": "https://github.com/decentraland/decentraland-eth.git"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "common",
-    "modules",
-    "decentraland"
-  ],
+  "files": ["dist"],
+  "keywords": ["common", "modules", "decentraland"],
   "author": "Decentraland",
   "license": "ISC",
   "dependencies": {

--- a/specs/Contracts.spec.ts
+++ b/specs/Contracts.spec.ts
@@ -84,7 +84,8 @@ function doTest() {
     expect(typeof txRecipt.contractAddress).to.eq('string')
     expect(txRecipt.contractAddress.length).to.be.greaterThan(0)
 
-    const x = await txUtils.getTransaction(contract.transactionHash)
+    /* tslint:disable-next-line:no-unnecessary-type-assertion */
+    const x = (await txUtils.getTransaction(contract.transactionHash)) as txUtils.ConfirmedTransaction
     expect(typeof x).eq('object')
     expect(x.hash).eq(contract.transactionHash)
     expect(typeof x.receipt).eq('object')

--- a/specs/eth.spec.ts
+++ b/specs/eth.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai'
+import { NodeConnectionFactory } from './NodeConnectionFactory'
+import { eth, txUtils } from '../dist'
+
+describe('Eth tests', () => {
+  const nodeConnectionFactory = new NodeConnectionFactory()
+  let provider
+
+  before(() => {
+    provider = nodeConnectionFactory.createProvider()
+    return eth.connect({ provider })
+  })
+
+  describe('.getTransactionsByAccount', function() {
+    it('should return the right amount of txs', async function() {
+      const account = eth.getAccount()
+
+      const txId = await eth.wallet.sendTransaction({ from: account })
+      await txUtils.getConfirmedTransaction(txId)
+      const txs = await eth.getTransactionsByAccount(account)
+      expect(txs.length).to.be.equal(1)
+
+      const txId2 = await eth.wallet.sendTransaction({ from: account })
+      await txUtils.getConfirmedTransaction(txId2)
+      const txs2 = await eth.getTransactionsByAccount(account)
+      expect(txs2.length).to.be.equal(2)
+    })
+  })
+})

--- a/specs/remoteProvider.spec.ts
+++ b/specs/remoteProvider.spec.ts
@@ -57,11 +57,12 @@ describe('ETH using url provider (mainnet)', function() {
     expect(invalidTx).to.be.equal(null)
   })
 
-  it('should work and identify failed transactions', async function() {
+  it('should work and identify reverted transactions', async function() {
     this.timeout(30000)
-    const failedTx = await txUtils.getTransaction(mainnetFailedTransaction)
+    /* tslint:disable-next-line:no-unnecessary-type-assertion */
+    const failedTx = (await txUtils.getTransaction(mainnetFailedTransaction)) as txUtils.RevertedTransaction
 
-    expect(txUtils.isFailure(failedTx)).to.be.equal(true)
+    expect(failedTx.type).to.be.equal('reverted')
   })
 
   it('should get the status of a transaction', async function() {

--- a/specs/txUtils.spec.ts
+++ b/specs/txUtils.spec.ts
@@ -4,7 +4,6 @@ import { deployContract } from './deployContract'
 import { eth, txUtils } from '../dist'
 
 describe('txUtils tests', () => {
-  const DEFAULT_FETCH_DELAY = txUtils.TRANSACTION_FETCH_DELAY
   const nodeConnectionFactory = new NodeConnectionFactory()
   let provider
 
@@ -14,13 +13,17 @@ describe('txUtils tests', () => {
   })
 
   describe('.getTransaction', function() {
-    it('should return the transaction status and its receipt', async function() {
+    it('should return the confirmed transaction status and its receipt', async function() {
       this.timeout(100000)
 
       const contract = await deployContract(eth.wallet, 'MANA', require('./fixtures/MANAToken.json'))
-      const { receipt, ...tx } = await txUtils.getTransaction(contract.transactionHash)
+      /* tslint:disable-next-line:no-unnecessary-type-assertion */
+      const { receipt, ...tx } = (await txUtils.getTransaction(
+        contract.transactionHash
+      )) as txUtils.ConfirmedTransaction
 
       expect(Object.keys(tx)).to.be.deep.equal([
+        'type',
         'hash',
         'nonce',
         'blockHash',
@@ -50,68 +53,18 @@ describe('txUtils tests', () => {
       expect(receipt.transactionHash).to.be.equal('0x505d58d5b6a38304deaad305ff2d773354cc939afc456562ba6bddbbf201e27f')
     })
 
-    it('should return null if the tx hash is invalid or dropped', async () => {
-      const invalidTx = await txUtils.getTransaction(
-        '0xc15c7dda554711eac29d4a983e53aa161dd1bdc6e1d013bb29da1f607916de1'
-      )
-      expect(invalidTx).to.be.equal(null)
-
-      const droppedTx = await txUtils.getTransaction(
-        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969'
-      )
-      expect(droppedTx).to.be.equal(null)
+    it('should return null for an unknown transaction', async function() {
+      const tx = await txUtils.getTransaction('0xfaceb00c')
+      expect(tx).to.be.null // tslint:disable-line
     })
   })
 
-  describe('.isTxDropped', function() {
-    it('should wait TRANSACTION_FETCH_DELAY for each retry attempts', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 50
-      const retryAttemps = 5
-      const totalTime = 5 * 50
-
-      const begining = Date.now()
-      await txUtils.isTxDropped('0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969', retryAttemps)
-      const end = Date.now()
-      const delay = end - begining
-
-      expect(delay).to.be.within(totalTime, totalTime + 100) // give it 100ms of leway
-    })
-
-    afterEach(() => {
-      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
-    })
-  })
-
-  describe('.waitForCompletion', function() {
-    it('should return a failed tx for a dropped hash', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 10
-
-      const droppedTx = await txUtils.waitForCompletion(
-        '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969'
-      )
-
-      expect(droppedTx).to.be.deep.equal({
-        hash: '0x24615f57f5754f2479d6657f7ac9a56006d8d6f634c6955310a5af1c79f4969',
-        status: txUtils.TRANSACTION_STATUS.failed,
-        isDropped: true
-      })
-    })
-
-    it('should return the full transaction after it finishes', async function() {
-      txUtils.TRANSACTION_FETCH_DELAY = 10
-
-      // compiled solidity source code
-      const code =
-        '603d80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463c6888fa18114602d57005b6007600435028060005260206000f3'
-      const txHash = await eth.wallet.sendTransaction({ data: code })
-      const tx = await txUtils.waitForCompletion(txHash)
-
-      expect(tx.hash).to.be.equal(txHash)
-      expect(tx.receipt).not.to.be.equal(undefined)
-    })
-
-    afterEach(() => {
-      txUtils.TRANSACTION_FETCH_DELAY = DEFAULT_FETCH_DELAY
+  describe('.getConfirmedTransaction', function() {
+    it('should return the confirmed transaction', async function() {
+      const account = eth.getAccount()
+      const txId = await eth.wallet.sendTransaction({ from: account })
+      const tx = await txUtils.getConfirmedTransaction(txId)
+      expect(tx.type).to.be.equal('confirmed')
     })
   })
 })

--- a/src/ethereum/wallets/Wallet.ts
+++ b/src/ethereum/wallets/Wallet.ts
@@ -1,7 +1,7 @@
 import { promisify } from '../../utils'
 import { Abi } from '../abi/Abi'
 
-export interface TxReceipt {
+export interface TransactionReceipt {
   transactionHash: string
   transactionIndex: number
   blockHash: string
@@ -14,10 +14,11 @@ export interface TxReceipt {
   logsBloom: string
 }
 
-export type TxStatus = {
+export type TransactionStatus = {
   hash: string
   nonce: number
   blockHash: string
+  blockNumber: number | null
   transactionIndex: number
   from: string
   to: string
@@ -121,7 +122,7 @@ export abstract class Wallet {
    * @param  {string} txId - Transaction id/hash
    * @return {object}      - An object describing the transaction (if it exists)
    */
-  async getTransactionStatus(txId: string): Promise<TxStatus> {
+  async getTransactionStatus(txId: string): Promise<TransactionStatus> {
     return promisify(this.getWeb3().eth.getTransaction)(txId)
   }
 
@@ -130,7 +131,7 @@ export abstract class Wallet {
    * @param  {string} txId - Transaction id/hash
    * @return {object} - An object describing the transaction receipt (if it exists) with it's logs
    */
-  async getTransactionReceipt(txId: string): Promise<TxReceipt> {
+  async getTransactionReceipt(txId: string): Promise<TransactionReceipt> {
     const receipt = await promisify(this.getWeb3().eth.getTransactionReceipt)(txId)
 
     if (receipt && receipt.logs) {


### PR DESCRIPTION
This PR changes the way we get transactions. The biggest change it's that it removes the retry logic that was causing LOTS of false dropped transaction.

Instead here we are using the network to figure out the status of the transaction, by using the account's current nonce.

The previous status types were `confirmed`, `pending` and `failed`. I changed `failed` for `reverted` and added `dropped`, `replaced` and `queued`, so we can be able to give more feedback to the users regarding the status of their transactions.

I removed the helpers `isFailure`, `isDropped`, `isTxDropped` and `waitForCompletion` since they are redundant now (all the use cases can be fulfilled with `getTransaction` and `getConfirmedTransaction`).

The way `getTransaction` works hasn't changed for the end user, it returns a `tx` or `null` if the transaction is not known by the node. The difference is that the `tx` now has more possible statuses.

The way `getConfirmedTransaction` works is still the same for the end user, it waits for the confirmed tx and throws if the transactions is reverted or dropped/replaced. The main difference is that now it doesn't use a retry logic to drop the transaction, it checks against the network.

I also added a few handy methods like `eth.getCurrentNonce`, `eth.getBlockNumber`, `eth.getBlock`, and `eth.getTransactionsByAccount`

# HOW TO TEST

You can test these features by testing this PR https://github.com/decentraland/gate/pull/21