### PR TITLE
fix: wrong replaced tx

### DIFF
--- a/src/ethereum/txUtils.ts
+++ b/src/ethereum/txUtils.ts
@@ -69,6 +69,7 @@ export namespace txUtils {
     | RevertedTransaction
 
   export async function getTransaction(hash: string): Promise<Transaction> {
+    const currentNonce = await eth.getCurrentNonce()
     const status = await eth.wallet.getTransactionStatus(hash)
 
     // not found
@@ -77,8 +78,6 @@ export namespace txUtils {
     }
 
     if (status.blockNumber == null) {
-      const currentNonce = await eth.getCurrentNonce()
-
       // replaced
       if (status.nonce < currentNonce) {
         const tx: ReplacedTransaction = {

--- a/src/ethereum/txUtils.ts
+++ b/src/ethereum/txUtils.ts
@@ -69,7 +69,13 @@ export namespace txUtils {
     | RevertedTransaction
 
   export async function getTransaction(hash: string): Promise<Transaction> {
-    const currentNonce = await eth.getCurrentNonce()
+    let currentNonce
+    try {
+      currentNonce = await eth.getCurrentNonce()
+    } catch (error) {
+      currentNonce = null
+    }
+
     const status = await eth.wallet.getTransactionStatus(hash)
 
     // not found
@@ -78,24 +84,26 @@ export namespace txUtils {
     }
 
     if (status.blockNumber == null) {
-      // replaced
-      if (status.nonce < currentNonce) {
-        const tx: ReplacedTransaction = {
-          hash,
-          type: 'replaced',
-          nonce: status.nonce
+      if (currentNonce != null) {
+        // replaced
+        if (status.nonce < currentNonce) {
+          const tx: ReplacedTransaction = {
+            hash,
+            type: 'replaced',
+            nonce: status.nonce
+          }
+          return tx
         }
-        return tx
-      }
 
-      // queued
-      if (status.nonce > currentNonce) {
-        const tx: QueuedTransaction = {
-          hash,
-          type: 'queued',
-          nonce: status.nonce
+        // queued
+        if (status.nonce > currentNonce) {
+          const tx: QueuedTransaction = {
+            hash,
+            type: 'queued',
+            nonce: status.nonce
+          }
+          return tx
         }
-        return tx
       }
 
       // pending


### PR DESCRIPTION
This PR changes the order on that we fetch the tx status and the account nonce to solve a race condition on which the status would return as pending (non `null` but with `null` blockNumber) and it will get mined before the `await eth.getCurrentNonce()` is resolved, resulting in a `replaced` tx.

By fetching the account nonce first, if the tx gets mined in between the calls to fetch the nonce and the tx status, the transaction will come back with a non `null` block number and it will be returned as `confirmed` (or `reverted`).