### PR TITLE
fix: force , as delimiter

### DIFF
--- a/src/contracts/LANDRegistry.ts
+++ b/src/contracts/LANDRegistry.ts
@@ -24,7 +24,9 @@ export class LANDRegistry extends Contract {
     const version = data.charAt(0)
     switch (version) {
       case '0': {
-        const [version, name, description, ipns] = CSV.parse(data)[0]
+        const [version, name, description, ipns] = CSV.parse(data, {
+          cellDelimiter: ','
+        })[0]
 
         return {
           version,


### PR DESCRIPTION
CSV parsing was using multiple chars as delimiters like `,` but also `|`. This should set it to only use `,`